### PR TITLE
Extendable head section in base.html

### DIFF
--- a/mkdocs_simple_blog/base.html
+++ b/mkdocs_simple_blog/base.html
@@ -71,6 +71,10 @@
             {% endif %}
 
         {%- endblock %}
+
+        {%- block head_extra_links %}
+          {% include "modules/head_extra_links.html" %}
+        {%- endblock %}
     </head>
 
     <body>


### PR DESCRIPTION
First, thanks for creating this theme!

Recently I wanted to add RSS feeds to my blog. I used the mkdocs_rss_plugin to generate the feed files, but I couldn't find a way to extend the theme to add links to these files to the head section on every page. 

I took a look at how it's done in material theme: https://github.com/squidfunk/mkdocs-material/blob/d205ef549cc6c0ccd00b58d6d4cc13119f49a182/material/templates/base.html#L30

I figured that you don't want this theme to have anything hardcoded relevant to  RSS or other plugins. I think having a template module in which we can put extra head links is good solution to my and similar situations. 