### PR TITLE
🪲 BUG: Fix unresolved merge conflict marker in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,11 +36,7 @@ Changelog = "https://fernandocelmer.github.io/mkdocs-simple-blog/nav/development
 
 [tool.poetry]
 name = "mkdocs-simple-blog"
-<<<<<<< HEAD
 version = "0.4.2"
-=======
-version = "0.4.2"
->>>>>>> develop
 description = "Mkdocs Blog Theme"
 authors = ["Fernando Celmer <email@fernandocelmer.com>"]
 license = "MIT"


### PR DESCRIPTION
## Description

`pyproject.toml` on `master` (and tag `v0.4.2`) has an unresolved Git merge conflict marker left in `[tool.poetry].version`:

```toml
<<<<<<< HEAD
version = "0.4.1"
=======
version = "0.4.2"
>>>>>>> develop
```

This makes the file invalid TOML, so `poetry install` fails with `Invalid statement (at line 39, column 1)`.

## Motivation and Context

Breaks CI on runs against `master`/`v0.4.2`:
- https://github.com/FernandoCelmer/mkdocs-simple-blog/actions/runs/30835049857 (Run Tests + Code Quality Checks)

`develop` already has this resolved correctly (`version = "0.4.2"`), so this fix just brings `master` in line with what was intended.

## Types of changes
- [x] Bug fix (change that fixes an issue)

## Checklist
- [x] Verified `pyproject.toml` parses as valid TOML after the fix