### PR TITLE
🪲 BUG-#92: Skip page-dates divider when page body is empty

### DIFF
--- a/mkdocs_simple_blog/modules/content.html
+++ b/mkdocs_simple_blog/modules/content.html
@@ -14,7 +14,9 @@
             {% if created %}Created on {{ created }}{% endif %}
             {% if updated and updated != created %} — updated on {{ updated }}{% endif %}
         </p>
+        {% if page.content and page.content.strip() %}
         <hr class="page-dates-divider">
+        {% endif %}
         {% endif %}
         <p>{{ page.content }}</p>
     </article>

--- a/tests/test_content_module.py
+++ b/tests/test_content_module.py
@@ -1,0 +1,50 @@
+"""Regression tests for issue #92 -- page-dates divider duplicating
+blog_list's own first-item border on pages with no body content.
+"""
+
+from __future__ import annotations
+
+import unittest
+from types import SimpleNamespace
+
+from jinja2 import Environment, FileSystemLoader
+
+from mkdocs_simple_blog.plugin.dates import format_date
+
+from .fixtures import THEME_DIR
+
+
+def _url_filter(path: str) -> str:
+    return path
+
+
+def _template_env() -> Environment:
+    env = Environment(loader=FileSystemLoader(str(THEME_DIR)), autoescape=True)
+    env.filters["url"] = _url_filter
+    env.filters["fmt_date"] = format_date
+    return env
+
+
+class PageDatesDividerTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.env = _template_env()
+        self.template = self.env.get_template("modules/content.html")
+
+    def _render(self, content: str) -> str:
+        config = SimpleNamespace(theme=SimpleNamespace(components=None))
+        page = SimpleNamespace(
+            title="Blog",
+            content=content,
+            meta={"date": "2024-01-05"},
+            file=None,
+        )
+        return self.template.render(config=config, page=page)
+
+    def test_no_divider_when_page_has_no_body_content(self) -> None:
+        html = self._render("")
+        self.assertIn("page-dates", html)
+        self.assertNotIn("page-dates-divider", html)
+
+    def test_divider_present_when_page_has_body_content(self) -> None:
+        html = self._render("<p>Some real body text.</p>")
+        self.assertIn("page-dates-divider", html)


### PR DESCRIPTION
## Description

Closes #92. `content.html` always rendered `<hr class="page-dates-divider">` whenever page dates were shown, regardless of whether there was any body content below it. On a pure blog-index page (`blog_list: true`, no body text), the divider sat right next to `blog_list`'s own first-item top border (`.blog-card`/`.blog-row`), showing as two adjacent horizontal rules.

## Motivation and Context

Closes #92.

## Types of changes

- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the CHANGELOG
- [ ] I have updated the documentation accordingly