### PR TITLE
⚠️ SECURITY-#94: Fix Dependabot alerts, drop Python 3.9 support

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - name: 📥 Checkout code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - name: 📥 Checkout code

--- a/docs/nav/development/development-guide.md
+++ b/docs/nav/development/development-guide.md
@@ -120,7 +120,7 @@ mypy --config-file=.code_quality/mypy.ini mkdocs_simple_blog/ tests/
 Code quality checks are automatically run:
 
 - On every push and pull request
-- For Python versions 3.9 through 3.14
+- For Python versions 3.10 through 3.14
 - Before package publication
 
 See `.github/workflows/code-quality.yml` for the CI configuration.
@@ -141,7 +141,7 @@ All code quality configurations are in the `.code_quality/` directory:
 
 The package is automatically published to TestPyPI when changes are pushed to the `pypi` branch. The publishing workflow:
 
-1. Runs all tests (Python 3.9-3.14)
+1. Runs all tests (Python 3.10-3.14)
 2. Runs code quality checks
 3. Builds the package
 4. Publishes to TestPyPI
@@ -152,7 +152,7 @@ See `.github/workflows/python-publish-pypi-test.yml` for the configuration.
 
 The package is automatically published to PyPI when a new release is published on GitHub. The publishing workflow:
 
-1. Runs all tests (Python 3.9-3.14)
+1. Runs all tests (Python 3.10-3.14)
 2. Runs code quality checks
 3. Builds the package
 4. Publishes to PyPI

--- a/docs/nav/development/testing.md
+++ b/docs/nav/development/testing.md
@@ -209,7 +209,6 @@ Tests are automatically run via GitHub Actions on:
 
 The CI pipeline tests the project across multiple Python versions:
 
-- Python 3.9
 - Python 3.10
 - Python 3.11
 - Python 3.12

--- a/poetry.lock
+++ b/poetry.lock
@@ -22,7 +22,6 @@ description = "The uncompromising code formatter."
 optional = false
 python-versions = ">=3.10"
 groups = ["code-quality"]
-markers = "python_version >= \"3.10\""
 files = [
     {file = "black-26.5.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:9942db8888e06943c5dde66ca0037dcff82a2a4ec1ad0ada9e0d2ee9d9823893"},
     {file = "black-26.5.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:89c93167a74d3a75dfaa38a5c7cca015537d5820dd7f17d63267d674a61cae90"},
@@ -103,7 +102,6 @@ files = [
     {file = "click-8.1.8-py3-none-any.whl", hash = "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2"},
     {file = "click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a"},
 ]
-markers = {code-quality = "python_version >= \"3.10\""}
 
 [package.dependencies]
 colorama = {version = "*", markers = "platform_system == \"Windows\""}
@@ -119,7 +117,7 @@ files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
-markers = {main = "platform_system == \"Windows\"", code-quality = "python_version >= \"3.10\" and platform_system == \"Windows\"", dev = "os_name == \"nt\" or sys_platform == \"win32\""}
+markers = {main = "platform_system == \"Windows\"", code-quality = "platform_system == \"Windows\"", dev = "os_name == \"nt\" or sys_platform == \"win32\""}
 
 [[package]]
 name = "coverage"
@@ -301,12 +299,12 @@ version = "8.7.0"
 description = "Read metadata from Python packages"
 optional = false
 python-versions = ">=3.9"
-groups = ["main", "dev"]
+groups = ["dev"]
+markers = "python_full_version < \"3.10.2\""
 files = [
     {file = "importlib_metadata-8.7.0-py3-none-any.whl", hash = "sha256:e5dd1551894c77868a30651cef00984d50e1002d06942a7101d34870c5f02afd"},
     {file = "importlib_metadata-8.7.0.tar.gz", hash = "sha256:d13b81ad223b890aa16c5471f2ac3056cf76c5f10f82d6f9292f0b415f389000"},
 ]
-markers = {main = "python_version == \"3.9\"", dev = "python_full_version < \"3.10.2\""}
 
 [package.dependencies]
 zipp = ">=3.20"
@@ -463,9 +461,6 @@ files = [
     {file = "markdown-3.9.tar.gz", hash = "sha256:d2900fe1782bd33bdbbd56859defef70c2e78fc46668f8eb9df3128138f2cb6a"},
 ]
 
-[package.dependencies]
-importlib-metadata = {version = ">=4.4", markers = "python_version < \"3.10\""}
-
 [package.extras]
 docs = ["mdx_gh_links (>=0.2)", "mkdocs (>=1.6)", "mkdocs-gen-files", "mkdocs-literate-nav", "mkdocs-nature (>=0.6)", "mkdocs-section-index", "mkdocstrings[python]"]
 testing = ["coverage", "pyyaml"]
@@ -609,7 +604,6 @@ files = [
 click = ">=7.0"
 colorama = {version = ">=0.4", markers = "platform_system == \"Windows\""}
 ghp-import = ">=1.0"
-importlib-metadata = {version = ">=4.4", markers = "python_version < \"3.10\""}
 jinja2 = ">=2.11.1"
 markdown = ">=3.3.6"
 markupsafe = ">=2.0.1"
@@ -638,7 +632,6 @@ files = [
 ]
 
 [package.dependencies]
-importlib-metadata = {version = ">=4.3", markers = "python_version < \"3.10\""}
 mergedeep = ">=1.3.4"
 platformdirs = ">=2.2.0"
 pyyaml = ">=5.1"
@@ -728,7 +721,6 @@ files = [
     {file = "packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484"},
     {file = "packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f"},
 ]
-markers = {code-quality = "python_version >= \"3.10\""}
 
 [[package]]
 name = "pathspec"
@@ -758,7 +750,6 @@ files = [
     {file = "platformdirs-4.4.0-py3-none-any.whl", hash = "sha256:abd01743f24e5287cd7a5db3752faf1a2d65353f38ec26d98e25a6db65958c85"},
     {file = "platformdirs-4.4.0.tar.gz", hash = "sha256:ca753cf4d81dc309bc67b0ea38fd15dc97bc30ce419a7f58d13eb3bf14c4febf"},
 ]
-markers = {code-quality = "python_version >= \"3.10\""}
 
 [package.extras]
 docs = ["furo (>=2024.8.6)", "proselint (>=0.14)", "sphinx (>=8.1.3)", "sphinx-autodoc-typehints (>=3)"]
@@ -822,14 +813,14 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pymdown-extensions"
-version = "10.21.3"
+version = "11.0.1"
 description = "Extension pack for Python Markdown."
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["dev"]
 files = [
-    {file = "pymdown_extensions-10.21.3-py3-none-any.whl", hash = "sha256:d7a5d08014fc571e80ca21dd6f854e31f94c489800350564d55d15b3c41e76b6"},
-    {file = "pymdown_extensions-10.21.3.tar.gz", hash = "sha256:72cfcf55f07aea0d4af2c4f11dd4e52466ddfb1bb819673146398e0bd3a77354"},
+    {file = "pymdown_extensions-11.0.1-py3-none-any.whl", hash = "sha256:db3943a62bab7e03af1364f0c4083e64b91fb097675a4b6cceccfbe9a77e5eb2"},
+    {file = "pymdown_extensions-11.0.1.tar.gz", hash = "sha256:dd2905ae6fc5b75582fafb139a1266ffc754705efa902aa50067fa7ff4f94ec0"},
 ]
 
 [package.dependencies]
@@ -853,37 +844,11 @@ files = [
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
-description = "pytest: simple powerful testing with Python"
-optional = false
-python-versions = ">=3.9"
-groups = ["dev"]
-markers = "python_version == \"3.9\""
-files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
-]
-
-[package.dependencies]
-colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
-exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
-pluggy = ">=1.5,<2"
-pygments = ">=2.7.2"
-tomli = {version = ">=1", markers = "python_version < \"3.11\""}
-
-[package.extras]
-dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "requests", "setuptools", "xmlschema"]
-
-[[package]]
-name = "pytest"
 version = "9.1.1"
 description = "pytest: simple powerful testing with Python"
 optional = false
 python-versions = ">=3.10"
 groups = ["dev"]
-markers = "python_version >= \"3.10\""
 files = [
     {file = "pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c"},
     {file = "pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313"},
@@ -960,7 +925,6 @@ description = "A Fast, spec compliant Python 3.14+ tokenizer that runs on older 
 optional = false
 python-versions = ">=3.8"
 groups = ["code-quality"]
-markers = "python_version >= \"3.10\""
 files = [
     {file = "pytokens-0.4.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2a44ed93ea23415c54f3face3b65ef2b844d96aeb3455b8a69b3df6beab6acc5"},
     {file = "pytokens-0.4.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:add8bf86b71a5d9fb5b89f023a80b791e04fba57960aa790cc6125f7f1d39dfe"},
@@ -1262,12 +1226,12 @@ version = "3.23.0"
 description = "Backport of pathlib-compatible object wrapper for zip files"
 optional = false
 python-versions = ">=3.9"
-groups = ["main", "dev"]
+groups = ["dev"]
+markers = "python_full_version < \"3.10.2\""
 files = [
     {file = "zipp-3.23.0-py3-none-any.whl", hash = "sha256:071652d6115ed432f5ce1d34c336c0adfd6a884660d1e9712a256d3d3bd4b14e"},
     {file = "zipp-3.23.0.tar.gz", hash = "sha256:a07157588a12518c9d4034df3fbbee09c814741a33ff63c05fa29d26a2404166"},
 ]
-markers = {main = "python_version == \"3.9\"", dev = "python_full_version < \"3.10.2\""}
 
 [package.extras]
 check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1) ; sys_platform != \"cygwin\""]
@@ -1279,5 +1243,5 @@ type = ["pytest-mypy"]
 
 [metadata]
 lock-version = "2.1"
-python-versions = ">=3.9.0"
-content-hash = "3b62c3e8f7416126c9749543b61ef2696a6d4114f52eee9c60efbdb508a18175"
+python-versions = ">=3.10.0"
+content-hash = "81ece2a4e564065d4b024165d1df4198b04b409f67c413e8bf13a5bed5f24058"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ maintainers = [
 license = {file = "LICENSE"}
 description = "Mkdocs Blog Theme"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = ["mkdocs>=1.6.1,<2.0.0", "babel>=2.9.0"]
 keywords = ["mkdocs", "blog", "theme", "documentation"]
 classifiers = [
@@ -18,7 +18,6 @@ classifiers = [
   "Operating System :: OS Independent",
   'Intended Audience :: Developers',
   'Natural Language :: English',
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
@@ -43,26 +42,23 @@ license = "MIT"
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = ">=3.9.0"
+python = ">=3.10.0"
 mkdocs = { version = ">=1.6.1,<2.0.0" }
 babel = { version = ">=2.9.0" }
 
 [tool.poetry.group.dev.dependencies]
 build = "^1.3.0"
-pytest = [
-  { version = "^8.0.0", python = ">=3.9,<3.10" },
-  { version = "^9.0.3", python = ">=3.10" },
-]
+pytest = "^9.0.3"
 pytest-cov = "^4.0.0"
 pytest-mock = "^3.12.0"
 jinja2 = "^3.1.0"
-pymdown-extensions = "^10.0"
+pymdown-extensions = "^11.0.1"
 
 [tool.poetry.group.code-quality.dependencies]
 ruff = "^0.6.0"
 flake8 = "^7.0.0"
 mypy = "^1.8.0"
-black = { version = "^26.3.1", python = ">=3.10" }
+black = "^26.3.1"
 isort = "^5.13.0"
 
 [build-system]


### PR DESCRIPTION
## Description

Closes #94. 3 open Dependabot alerts:

| Severity | Package | Issue | Patched in |
|----------|---------|-------|------------|
| High | pymdown-extensions | Exponential-backtracking ReDoS in caret/tilde/betterem/magiclink | 11.0.1 |
| Medium | pymdown-extensions | Path traversal in `b64` extension | 11.0.0 |
| Medium | pytest | Vulnerable `tmpdir` handling | 9.0.3 |

Both `pymdown-extensions==11.0.1` and `pytest==9.0.3` require Python `>=3.10` upstream — there's no 3.9-compatible release with either fix. Bumping them means dropping Python 3.9 support:

- `requires-python` bumped to `>=3.10` (both `[project]` and `[tool.poetry.dependencies]`)
- `3.9` classifier removed
- `pytest` constraint simplified to a single `^9.0.3` (was split `^8.0.0`/`^9.0.3` by Python version)
- `black`'s `python = ">=3.10"` marker dropped (redundant now that the whole package requires 3.10+)
- CI test matrix (`test.yml`, `code-quality.yml`) drops the 3.9 job
- Docs updated to reflect the 3.10-3.14 matrix

## Motivation and Context

Closes #94.

## Types of changes

- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change which adds functionality)
- [x] Documentation
- [x] Security

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the CHANGELOG
- [x] I have updated the documentation accordingly