### PR TITLE
🪲 BUG-#96: Fix crash when simple-blog-posts plugin isn't installed

### DIFF
--- a/mkdocs_simple_blog/modules/blog_list_compact.html
+++ b/mkdocs_simple_blog/modules/blog_list_compact.html
@@ -18,7 +18,7 @@
                 </h2>
             </div>
             <p class="blog-row-meta">
-                {{ post.date | fmt_date }}{% if post.category %} · {{ post.category }}{% endif %}{% if post.author %} · {{ post.author }}{% endif %}
+                {{ fmt_date(post.date) if fmt_date is defined else post.date }}{% if post.category %} · {{ post.category }}{% endif %}{% if post.author %} · {{ post.author }}{% endif %}
             </p>
             {% if post.description %}
             <p class="blog-row-description">{{ post.description }}</p>

--- a/mkdocs_simple_blog/modules/blog_list_featured.html
+++ b/mkdocs_simple_blog/modules/blog_list_featured.html
@@ -7,7 +7,7 @@
             <a href="{{ post.url|url }}">{{ post.title }}</a>
         </h2>
         <p class="blog-card-meta">
-            Published on {{ post.date | fmt_date }}
+            Published on {{ fmt_date(post.date) if fmt_date is defined else post.date }}
             {%- if post.category %} — in {{ post.category }}{% endif %}
             {%- if post.author %} — by
                 {%- if post.avatar_url %} <img class="blog-card-avatar" src="{{ post.avatar_url }}" alt="{{ post.author }}" loading="lazy">{% endif %}

--- a/mkdocs_simple_blog/modules/content.html
+++ b/mkdocs_simple_blog/modules/content.html
@@ -7,8 +7,8 @@
                 <h1 class="{{ config.theme.title_style }} title" id="component-title">{{ page.title }}</h1>
             {% endif %}
         </header>
-        {% set created = ((page.meta.date | fmt_date) if page.meta.date else page.meta.git_creation_date_localized) if page else None %}
-        {% set updated = ((page.meta.updated | fmt_date) if page.meta.updated else page.meta.git_revision_date_localized) if page else None %}
+        {% set created = ((fmt_date(page.meta.date) if fmt_date is defined else page.meta.date) if page.meta.date else page.meta.git_creation_date_localized) if page else None %}
+        {% set updated = ((fmt_date(page.meta.updated) if fmt_date is defined else page.meta.updated) if page.meta.updated else page.meta.git_revision_date_localized) if page else None %}
         {% if (created or updated) and not (config.theme.components and config.theme.components.page_dates == False) %}
         <p class="page-dates">
             {% if created %}Created on {{ created }}{% endif %}

--- a/mkdocs_simple_blog/plugin/__init__.py
+++ b/mkdocs_simple_blog/plugin/__init__.py
@@ -47,9 +47,9 @@ class BlogPlugin(BasePlugin[BlogPluginConfig]):
 
     def on_env(self, env, config, files):
         locale = config.theme.get("locale") or "en"
-        env.filters["fmt_date"] = lambda value: format_date(
-            value, locale=locale
-        )
+        bound_format_date = lambda value: format_date(value, locale=locale)  # noqa: E731
+        env.filters["fmt_date"] = bound_format_date
+        env.globals["fmt_date"] = bound_format_date
         return env
 
     def on_files(self, files, config):

--- a/tests/modules/test_modules.py
+++ b/tests/modules/test_modules.py
@@ -106,6 +106,7 @@ class BlogListDateFormattingTests(unittest.TestCase):
         )
         self.env.filters["url"] = lambda path: path
         self.env.filters["fmt_date"] = format_date
+        self.env.globals["fmt_date"] = format_date
         self.post = {
             "title": "A",
             "url": "post/a/",

--- a/tests/plugin/test_blog_plugin.py
+++ b/tests/plugin/test_blog_plugin.py
@@ -38,11 +38,12 @@ class BlogPluginTests(unittest.TestCase):
         if not dates_module._HAS_BABEL:
             self.skipTest("babel not installed")
 
-        env = SimpleNamespace(filters={})
+        env = SimpleNamespace(filters={}, globals={})
         self.plugin.on_env(env, config=fake_config(locale="pt"), files=[])
 
         formatted = env.filters["fmt_date"](datetime.date(2024, 1, 5))
         self.assertEqual(formatted, "5 de janeiro de 2024")
+        self.assertIs(env.globals["fmt_date"], env.filters["fmt_date"])
 
     def _file(self, rel_path: str) -> File:
         return make_file(self.temp_dir, rel_path)

--- a/tests/test_content_module.py
+++ b/tests/test_content_module.py
@@ -1,6 +1,4 @@
-"""Regression tests for issue #92 -- page-dates divider duplicating
-blog_list's own first-item border on pages with no body content.
-"""
+"""Tests for modules/content.html and the blog_list templates."""
 
 from __future__ import annotations
 
@@ -53,11 +51,10 @@ class PageDatesDividerTests(unittest.TestCase):
 
 
 class MissingFmtDateFilterTests(unittest.TestCase):
-    """Regression tests for issue #96 -- content.html crashed on any page
-    with a `date` in front matter when the `simple-blog-posts` plugin
-    wasn't installed/enabled, since `fmt_date` is only ever registered by
-    that plugin's `on_env` hook, yet page_dates is on by default and
-    content.html is the theme's own base template, used by every page."""
+    """`fmt_date` is only registered by BlogPlugin.on_env, which only
+    runs if `simple-blog-posts` is installed -- but page_dates is on by
+    default and content.html is the theme's own base template, used by
+    every page, regardless of whether that plugin is enabled."""
 
     def setUp(self) -> None:
         self.env = _template_env(register_fmt_date=False)
@@ -75,3 +72,34 @@ class MissingFmtDateFilterTests(unittest.TestCase):
         )
         html = self.template.render(config=config, page=page)
         self.assertIn("2025-09-15", html)
+
+
+class BlogListMissingFmtDateFilterTests(unittest.TestCase):
+    """A filter used directly inside a `{% for %}` (not a soft frame) is
+    validated at template *compile* time, so this crashed even when
+    `blog_posts` was empty, not just when the loop body actually ran."""
+
+    def setUp(self) -> None:
+        self.env = _template_env(register_fmt_date=False)
+        self.post = {
+            "title": "A",
+            "url": "post/a/",
+            "date": "2024-01-05",
+            "category": "",
+            "tags": [],
+            "author": "",
+            "avatar_url": "",
+            "description": "",
+            "image": "",
+        }
+        self.config = SimpleNamespace(theme=SimpleNamespace(blog=None))
+
+    def test_featured_layout_renders_without_crashing(self) -> None:
+        template = self.env.get_template("modules/blog_list_featured.html")
+        html = template.render(blog_posts=[self.post], config=self.config)
+        self.assertIn("2024-01-05", html)
+
+    def test_compact_layout_renders_without_crashing(self) -> None:
+        template = self.env.get_template("modules/blog_list_compact.html")
+        html = template.render(blog_posts=[self.post], config=self.config)
+        self.assertIn("2024-01-05", html)

--- a/tests/test_content_module.py
+++ b/tests/test_content_module.py
@@ -18,10 +18,12 @@ def _url_filter(path: str) -> str:
     return path
 
 
-def _template_env() -> Environment:
+def _template_env(*, register_fmt_date: bool = True) -> Environment:
     env = Environment(loader=FileSystemLoader(str(THEME_DIR)), autoescape=True)
     env.filters["url"] = _url_filter
-    env.filters["fmt_date"] = format_date
+    if register_fmt_date:
+        env.filters["fmt_date"] = format_date
+        env.globals["fmt_date"] = format_date
     return env
 
 
@@ -48,3 +50,28 @@ class PageDatesDividerTests(unittest.TestCase):
     def test_divider_present_when_page_has_body_content(self) -> None:
         html = self._render("<p>Some real body text.</p>")
         self.assertIn("page-dates-divider", html)
+
+
+class MissingFmtDateFilterTests(unittest.TestCase):
+    """Regression tests for issue #96 -- content.html crashed on any page
+    with a `date` in front matter when the `simple-blog-posts` plugin
+    wasn't installed/enabled, since `fmt_date` is only ever registered by
+    that plugin's `on_env` hook, yet page_dates is on by default and
+    content.html is the theme's own base template, used by every page."""
+
+    def setUp(self) -> None:
+        self.env = _template_env(register_fmt_date=False)
+        self.template = self.env.get_template("modules/content.html")
+
+    def test_renders_without_crashing_when_plugin_is_not_installed(
+        self,
+    ) -> None:
+        config = SimpleNamespace(theme=SimpleNamespace(components=None))
+        page = SimpleNamespace(
+            title="Test",
+            content="<p>A test file</p>",
+            meta={"date": "2025-09-15"},
+            file=None,
+        )
+        html = self.template.render(config=config, page=page)
+        self.assertIn("2025-09-15", html)


### PR DESCRIPTION
## Description

- **mkdocs_simple_blog/plugin/__init__.py**: Register `fmt_date` as both a Jinja filter and global with the same bound function
- **mkdocs_simple_blog/modules/content.html**: Replace pipe filter syntax with function call, add `fmt_date is defined` check to gracefully fallback to raw date when plugin is not active
- **mkdocs_simple_blog/modules/blog_list_featured.html**: Replace pipe filter syntax with function call, add `fmt_date is defined` check
- **mkdocs_simple_blog/modules/blog_list_compact.html**: Replace pipe filter syntax with function call, add `fmt_date is defined` check
- **tests/plugin/test_blog_plugin.py**: Assert that `fmt_date` is registered in both filters and globals dictionaries
- **tests/modules/test_modules.py**: Register `fmt_date` in globals when setting up test environment
- **tests/test_content_module.py**: Add comprehensive tests for missing `fmt_date` filter scenarios (MissingFmtDateFilterTests, BlogListMissingFmtDateFilterTests)

## Motivation and Context

Closes #96. The `content.html` template unconditionally applied `fmt_date` filter to date fields, but this filter is only registered by `BlogPlugin.on_env`, which only runs if `simple-blog-posts` is in the site's `plugins:`. Since `page_dates` is enabled by default, users who upgraded without adding the plugin experienced crashes with `jinja2.exceptions.TemplateRuntimeError: No filter named 'fmt_date' found`.

By registering `fmt_date` as both a filter and a global function, and adding defensive `fmt_date is defined` checks in templates, we ensure graceful degradation: the plugin remains optional, dates format nicely when it's active, and plain dates render unformatted (but without crashing) when it's not.

## Types of changes

- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the CHANGELOG
- [ ] I have updated the documentation accordingly